### PR TITLE
Html2Text converting UTF-8 fix

### DIFF
--- a/Html2Text.php
+++ b/Html2Text.php
@@ -59,7 +59,7 @@ class Html2Text
 
         $doc = new \DOMDocument('1.0', 'UTF-8');
         $prevValue = libxml_use_internal_errors(true);
-        $loaded = $doc->loadHTML($html);
+        $loaded = $doc->loadHTML( mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8") );
         libxml_use_internal_errors($prevValue);
         if (!$loaded) {
             throw new Html2TextException("Could not load HTML - badly formed?", $html);


### PR DESCRIPTION
Mėginant 'užkrauti' duomenis į DOMDocument kai kurie simboliai išsikraipo. Aktualiausia kalbama apie lietuviškas raides.
Su šia problema šis 'fiksas' išsprendžia problemą. Reiktu atlikti platesnį testavimą.